### PR TITLE
Added RadioExpandable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@
 * Added NiceFutureUtils
 
 ## 1.3.0
+
+* Added RadioExpandableProvider
+* Added RadioExpandable
+* Added RadioExpandableCard

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,10 +12,12 @@ void main() async {
 
   await NiceConfig.setup(
     onboardingConfig: NiceOnboardingGlobalConfig(),
-    baseCubitConfig: NiceBaseCubitConfig(wrapErrorHandler: (e, s) {
-      print(e);
-      print(s);
-    }),
+    baseCubitConfig: NiceBaseCubitConfig(
+      wrapErrorHandler: (e, s) {
+        print(e);
+        print(s);
+      },
+    ),
   );
 
   runApp(MyApp());

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:example/pages/auth/auth.page.dart';
 import 'package:example/pages/home.page.dart';
 import 'package:example/pages/onboarding.page.dart';
 import 'package:example/pages/page-view-form.page.dart';
+import 'package:example/pages/radio-expandable-cards.page.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nice_flutter_kit/nice_flutter_kit.dart';
@@ -11,12 +12,10 @@ void main() async {
 
   await NiceConfig.setup(
     onboardingConfig: NiceOnboardingGlobalConfig(),
-    baseCubitConfig: NiceBaseCubitConfig(
-      wrapErrorHandler: (e, s) {
-        print(e);
-        print(s);
-      }
-    ),
+    baseCubitConfig: NiceBaseCubitConfig(wrapErrorHandler: (e, s) {
+      print(e);
+      print(s);
+    }),
   );
 
   runApp(MyApp());
@@ -38,6 +37,11 @@ class MyApp extends StatelessWidget {
       path: "/auth",
       title: "Auth",
       child: AuthPage(),
+    ),
+    RouteData(
+      path: "/radio-expandable-cards",
+      title: "Radio expandable cards",
+      child: RadioExpandableCardsPage(),
     ),
   ];
 

--- a/example/lib/pages/radio-expandable-cards.page.dart
+++ b/example/lib/pages/radio-expandable-cards.page.dart
@@ -1,0 +1,63 @@
+import 'package:example/pages/common/base.page.dart';
+import 'package:flutter/material.dart';
+import 'package:nice_flutter_kit/nice_flutter_kit.dart';
+
+class RadioExpandableCardsPage extends StatelessWidget {
+  const RadioExpandableCardsPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return BasePage(
+      title: "Radio expandable cards",
+      child: RadioExpandableProvider(
+        child: ListView.separated(
+          itemCount: 50,
+          itemBuilder: (_, index) {
+            if (index % 5 == 0)
+              return Padding(
+                padding: const EdgeInsets.fromLTRB(32, 20, 32, 0),
+                child: Text("This is title #$index"),
+              );
+
+            return _buildCard(index);
+          },
+          separatorBuilder: (_, __) => const SizedBox(height: 20),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCard(int index) {
+    return RadioExpandableCard(
+      key: ValueKey(index),
+      cardMargin: const EdgeInsets.symmetric(horizontal: 32),
+      cardDecoration: const BoxDecoration(
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: Color(0x0B000000),
+            spreadRadius: 8,
+            blurRadius: 4,
+          ),
+        ],
+        borderRadius: BorderRadius.all(Radius.circular(8)),
+      ),
+      headerDecoration: const BoxDecoration(
+        borderRadius: BorderRadius.all(Radius.circular(8)),
+      ),
+      headerPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      headerAlignment: Alignment.center,
+      header: Text("Card #$index"),
+      bodyPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      body: Column(
+        children: [
+          const Text("This"),
+          const Text("is"),
+          const Text("card"),
+          Text("$index"),
+        ],
+      ),
+      separator: const Divider(height: 24, thickness: 2, endIndent: 20),
+    );
+  }
+}

--- a/example/lib/pages/radio-expandable-cards.page.dart
+++ b/example/lib/pages/radio-expandable-cards.page.dart
@@ -10,6 +10,7 @@ class RadioExpandableCardsPage extends StatelessWidget {
     return BasePage(
       title: "Radio expandable cards",
       child: RadioExpandableProvider(
+        initialExpandedKey: const ValueKey(42),
         child: ListView.separated(
           itemCount: 50,
           itemBuilder: (_, index) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -295,7 +295,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.3.0"
   notification_permissions:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -57,6 +57,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.3"
+  expandable:
+    dependency: "direct main"
+    description:
+      name: expandable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.1"
   ffi:
     dependency: transitive
     description:
@@ -288,7 +295,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.2.0"
   notification_permissions:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   nice_flutter_kit:
     path: ../
   reactive_forms: 11.0.1
+  expandable: ^5.0.1
 
 flutter:
   uses-material-design: true

--- a/lib/src/widgets/public.dart
+++ b/lib/src/widgets/public.dart
@@ -6,5 +6,6 @@ export 'nice-button.widget.dart';
 export 'nice-error.widget.dart';
 export 'nice-loading-overlay.widget.dart';
 export 'nice-text-accent-punctuation.widget.dart';
+export 'radio-expandable/public.dart';
 export 'reactive-checklist-validator.widget.dart';
 export 'typed-button.widget.dart';

--- a/lib/src/widgets/radio-expandable/public.dart
+++ b/lib/src/widgets/radio-expandable/public.dart
@@ -1,0 +1,4 @@
+export 'radio-expandable-card.widget.dart';
+export 'radio-expandable-provider-not-found.exception.dart';
+export 'radio-expandable-provider.widget.dart';
+export 'radio-expandable.widget.dart';

--- a/lib/src/widgets/radio-expandable/radio-expandable-card.widget.dart
+++ b/lib/src/widgets/radio-expandable/radio-expandable-card.widget.dart
@@ -1,0 +1,214 @@
+import 'package:expandable/expandable.dart';
+import 'package:flutter/material.dart';
+import 'package:nice_flutter_kit/nice_flutter_kit.dart';
+
+/// Similar to [RadioExpandable], but displays the [header] and [body] in a cord.
+/// It also handles the tap to expand / collapse the expandable
+class RadioExpandableCard extends StatefulWidget {
+  /// Decoration that will be displayed underneath this entire widget
+  final BoxDecoration? cardDecoration;
+
+  /// Padding that will be displayed around the content of the card, inside [cardDecoration]
+  final EdgeInsets? cardPadding;
+
+  /// Margin that will be placed around [cardDecoration]
+  final EdgeInsets? cardMargin;
+
+  /// Widget that will be displayed when the expandable in collapsed
+  final Widget header;
+
+  /// Padding that will be placed around [header]
+  /// This padding will be displayed inside [headerDecoration], if provided
+  final EdgeInsets? headerPadding;
+
+  /// Alignment of the [header]
+  final Alignment? headerAlignment;
+
+  /// Decoration that will be underneath the [header]
+  final BoxDecoration? headerDecoration;
+
+  /// Margin that will be placed around [header]
+  /// This margin will be displayed outside [headerDecoration], if provided. Otherwise it will be around [header]
+  final EdgeInsets? headerMargin;
+
+  /// Widget that will be displayed when the expandable in expanded
+  final Widget body;
+
+  /// Padding that will be placed around [body]
+  final EdgeInsets? bodyPadding;
+
+  /// Alignment of the [body]
+  final Alignment? bodyAlignment;
+
+  /// Decoration that will be underneath the [body]
+  final BoxDecoration? bodyDecoration;
+
+  /// Margin that will be placed around [body]
+  /// This margin will be displayed outside [bodyDecoration], if provided. Otherwise, it will be around [body]
+  final EdgeInsets? bodyMargin;
+
+  /// Widget that will be displayed between [header] and [header] when the expandable in expanded
+  final Widget? separator;
+
+  /// Theme data that will be provided to [Expandable]
+  /// The UI properties of the theme will be ignored
+  final ExpandableThemeData? theme;
+
+  const RadioExpandableCard({
+    // Key is required since this is what is used to keep track of which RadioExpandable is expanded
+    required Key key,
+    this.cardDecoration,
+    this.cardPadding,
+    this.cardMargin,
+    required this.header,
+    this.headerPadding,
+    this.headerAlignment,
+    this.headerDecoration,
+    this.headerMargin,
+    required this.body,
+    this.bodyPadding,
+    this.bodyAlignment,
+    this.bodyDecoration,
+    this.bodyMargin,
+    this.separator,
+    this.theme,
+  }) : super(key: key);
+
+  @override
+  State<RadioExpandableCard> createState() => _RadioExpandableCardState();
+}
+
+class _RadioExpandableCardState extends State<RadioExpandableCard> {
+  final _controller = ExpandableController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget card = _buildRadioExpandable();
+
+    if (widget.cardPadding != null) {
+      card = Padding(
+        padding: widget.cardPadding!,
+        child: card,
+      );
+    }
+
+    if (widget.cardDecoration != null) {
+      card = DecoratedBox(
+        decoration: widget.cardDecoration!,
+        child: card,
+      );
+    }
+
+    if (widget.cardMargin != null) {
+      card = Padding(
+        padding: widget.cardMargin!,
+        child: card,
+      );
+    }
+
+    return card;
+  }
+
+  Widget _buildRadioExpandable() {
+    return RadioExpandable(
+      key: widget.key!,
+      controller: _controller,
+      header: _buildHeader(),
+      body: _buildBody(),
+      expandedBuilder: (_, header, body) => Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          header,
+          if (widget.separator != null) widget.separator!,
+          body,
+        ],
+      ),
+      theme: widget.theme,
+    );
+  }
+
+  Widget _buildHeader() {
+    Widget header = widget.header;
+    if (widget.headerPadding != null) {
+      header = Padding(
+        padding: widget.headerPadding!,
+        child: header,
+      );
+    }
+
+    if (widget.headerAlignment != null) {
+      header = Align(
+        alignment: widget.headerAlignment!,
+        child: header,
+      );
+    }
+
+    if (widget.headerDecoration != null) {
+      header = DecoratedBox(
+        decoration: widget.headerDecoration!,
+        child: header,
+      );
+    }
+
+    header = Material(
+      borderRadius: widget.headerDecoration?.borderRadius?.resolve(TextDirection.ltr),
+      color: widget.headerDecoration?.color ?? Colors.transparent,
+      child: SizedBox(
+        width: double.infinity,
+        child: InkWell(
+          borderRadius: widget.headerDecoration?.borderRadius?.resolve(TextDirection.ltr),
+          onTap: () => RadioExpandableProvider.of(context).setExpandedKey(_controller.expanded ? null : widget.key),
+          child: header,
+        ),
+      ),
+    );
+
+    if (widget.headerMargin != null) {
+      header = Padding(
+        padding: widget.headerMargin!,
+        child: header,
+      );
+    }
+
+    return header;
+  }
+
+  Widget _buildBody() {
+    Widget body = widget.body;
+    if (widget.bodyPadding != null) {
+      body = Padding(
+        padding: widget.bodyPadding!,
+        child: body,
+      );
+    }
+
+    if (widget.bodyAlignment != null) {
+      body = Align(
+        alignment: widget.bodyAlignment!,
+        child: body,
+      );
+    }
+
+    if (widget.bodyDecoration != null) {
+      body = DecoratedBox(
+        decoration: widget.bodyDecoration!,
+        child: body,
+      );
+    }
+
+    if (widget.bodyMargin != null) {
+      body = Padding(
+        padding: widget.bodyMargin!,
+        child: body,
+      );
+    }
+
+    return body;
+  }
+}

--- a/lib/src/widgets/radio-expandable/radio-expandable-provider-not-found.exception.dart
+++ b/lib/src/widgets/radio-expandable/radio-expandable-provider-not-found.exception.dart
@@ -1,0 +1,9 @@
+class RadioExpandableProviderNotFoundException implements Exception {
+  @override
+  String toString() {
+    return '''
+    Error: Could not find inherited widget of type RadioExpandableProviderData in context.
+    Make sure that `RadioExpandableProvider.of(context)` was called underneath a RadioExpandableProvider.
+    ''';
+  }
+}

--- a/lib/src/widgets/radio-expandable/radio-expandable-provider.widget.dart
+++ b/lib/src/widgets/radio-expandable/radio-expandable-provider.widget.dart
@@ -2,7 +2,10 @@ import 'package:flutter/widgets.dart';
 import 'package:nice_flutter_kit/nice_flutter_kit.dart';
 
 class RadioExpandableProvider extends StatefulWidget {
+  /// Key that will be initially expanded
   final Key? initialExpandedKey;
+
+  /// Child which will be able to listen to the expandedKey
   final Widget child;
 
   const RadioExpandableProvider({

--- a/lib/src/widgets/radio-expandable/radio-expandable-provider.widget.dart
+++ b/lib/src/widgets/radio-expandable/radio-expandable-provider.widget.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/widgets.dart';
+import 'package:nice_flutter_kit/nice_flutter_kit.dart';
+
+class RadioExpandableProvider extends StatefulWidget {
+  final Key? initialExpandedKey;
+  final Widget child;
+
+  const RadioExpandableProvider({
+    Key? key,
+    this.initialExpandedKey,
+    required this.child,
+  }) : super(key: key);
+
+  static RadioExpandableProviderData of(BuildContext context) {
+    final data = context.dependOnInheritedWidgetOfExactType<RadioExpandableProviderData>();
+
+    if (data == null) {
+      throw RadioExpandableProviderNotFoundException();
+    }
+
+    return data;
+  }
+
+  @override
+  State<RadioExpandableProvider> createState() => _RadioExpandableProviderState();
+}
+
+class _RadioExpandableProviderState extends State<RadioExpandableProvider> {
+  Key? _expandedKey;
+
+  void _setExpandedKey(Key? expandedKey) {
+    if (this._expandedKey == expandedKey) return;
+
+    setState(() {
+      _expandedKey = expandedKey;
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    _expandedKey = widget.initialExpandedKey;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RadioExpandableProviderData(
+      expandedKey: _expandedKey,
+      child: widget.child,
+      state: this,
+    );
+  }
+}
+
+class RadioExpandableProviderData extends InheritedWidget {
+  final Key? expandedKey;
+  final _RadioExpandableProviderState _state;
+
+  RadioExpandableProviderData({
+    required this.expandedKey,
+    required Widget child,
+    required _RadioExpandableProviderState state,
+  })  : _state = state,
+        super(child: child);
+
+  void setExpandedKey(Key? expandedKey) => _state._setExpandedKey(expandedKey);
+
+  @override
+  bool updateShouldNotify(covariant RadioExpandableProviderData oldWidget) {
+    return this.expandedKey != oldWidget.expandedKey;
+  }
+}

--- a/lib/src/widgets/radio-expandable/radio-expandable.widget.dart
+++ b/lib/src/widgets/radio-expandable/radio-expandable.widget.dart
@@ -1,0 +1,96 @@
+import 'package:expandable/expandable.dart';
+import 'package:flutter/widgets.dart';
+import 'package:nice_flutter_kit/nice_flutter_kit.dart';
+
+class RadioExpandable extends StatefulWidget {
+  /// Widget tha will be displayed when the expandable is collapsed
+  final Widget header;
+
+  /// Widget that will be displayed when the expandable is expanded
+  final Widget body;
+
+  /// Builder called in order to display the expanded state of the [Expandable]
+  ///
+  /// This could be used, for example, to display a [Column] containing the [header], a separator, and the [body]
+  /// If not provided, the expanded state will only display the [body]
+  final Widget Function(BuildContext context, Widget header, Widget body)? expandedBuilder;
+
+  /// Theme data that will be provided to the [Expandable]
+  final ExpandableThemeData? theme;
+
+  /// Controller that will be provided to the [Expandable]
+  final ExpandableController? controller;
+
+  const RadioExpandable({
+    // Key is required since this is what is used to keep track of which RadioExpandable is expanded
+    required Key key,
+    required this.header,
+    required this.body,
+    this.expandedBuilder,
+    this.theme,
+    this.controller,
+  }) : super(key: key);
+
+  @override
+  State<RadioExpandable> createState() => _RadioExpandableState();
+}
+
+class _RadioExpandableState extends State<RadioExpandable> {
+  late final ExpandableController? _localController;
+
+  ExpandableController get _controller => widget.controller ?? _localController!;
+
+  @override
+  void initState() {
+    super.initState();
+
+    if (widget.controller == null) {
+      _localController = ExpandableController();
+    } else {
+      _localController = null;
+      widget.controller?.addListener(_controllerListener);
+    }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    final expandedKey = RadioExpandableProvider.of(context).expandedKey;
+
+    if ((expandedKey == widget.key && !_controller.expanded) || (expandedKey != widget.key && _controller.expanded)) {
+      setState(() {
+        _controller.toggle();
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller?.removeListener(_controllerListener);
+    _localController?.dispose();
+    super.dispose();
+  }
+
+  void _controllerListener() {
+    if (widget.controller?.expanded ?? false) {
+      RadioExpandableProvider.of(context).setExpandedKey(widget.key);
+    } else {
+      final expandedKey = RadioExpandableProvider.of(context).expandedKey;
+
+      if (expandedKey == widget.key) {
+        RadioExpandableProvider.of(context).setExpandedKey(null);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Expandable(
+      theme: widget.theme,
+      controller: _controller,
+      collapsed: widget.header,
+      expanded: widget.expandedBuilder?.call(context, widget.header, widget.body) ?? widget.body,
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.3"
+  expandable:
+    dependency: "direct main"
+    description:
+      name: expandable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.1"
   ffi:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nice_flutter_kit
 description: A collection of nice widgets
-version: 1.2.0
+version: 1.3.0
 homepage: https://github.com/Recursyve/nice_flutter_kit
 
 environment:
@@ -17,6 +17,7 @@ dependencies:
   collection: ^1.15.0
   dio: ^4.0.0
   equatable: ^2.0.0
+  expandable: ^5.0.0
   firebase_messaging: ^11.0.0
   flutter_bloc: ^8.0.0
   flutter_keyboard_visibility: ^5.2.0


### PR DESCRIPTION
`RadioExpandable` in a wrapper around https://pub.dev/packages/expandable, and it makes it so that only 1 widget can be expanded at a time.

`RadioExpandable` and `RadioExpandableCard` must be placed underneath a `RadioExpandableProvider`, which is the widget that holds the key of the currently expanded expandable.

### RadioExpandable

This widget takes a key, a header and a body.
The key is required and must be unique, since it is used to determine which expandable panel should be expanded.

This widget doesn't do much UI-wise, it only listens to the `RadioExpandableProvider` and toggles the expandable depending on the expandedKey.

### RadioExpandableCard

This widget is a wrapper around `RadioExpanable`, that provides a way to easily customize the UI of the expandable.
Just like the `RadioExpandable` the key is required and must be unique.
This widget also handles the onTap on the header in order to toggle the expandable

<br/>

The way this works is different from other widgets like `Accordion` and `ExpansionPanelList`, because in this widget the RadioExpandable can be placed anywhere, so we can lazy load them in a `ListView`, or we can place widget in between them, e.g. a title.

Example:

https://user-images.githubusercontent.com/32107801/162989476-6a7f60b6-441b-4376-894d-60d80ac4480a.mov