### PR TITLE
Permettre à l'utilisateur de la niceBaseList de ne pas afficher le loading spinner par défaut.

### DIFF
--- a/lib/src/widgets/base-list/cubit/nice-base-list.cubit.dart
+++ b/lib/src/widgets/base-list/cubit/nice-base-list.cubit.dart
@@ -13,11 +13,11 @@ class NiceBaseListCubit<D> extends NiceBaseCubit<NiceBaseListState<D>> {
 
   factory NiceBaseListCubit.of(BuildContext context) => BlocProvider.of(context);
 
-  Future<void> load({bool showLoading = true}) async {
+  Future<void> load({bool loading = true}) async {
     emit(state.copyWith(error: false));
 
     await wrap(
-      loading: showLoading,
+      loading: loading,
       callback: () async {
         final result = await config.filterApi.filter(
           NiceFilterModel(

--- a/lib/src/widgets/base-list/cubit/nice-base-list.cubit.dart
+++ b/lib/src/widgets/base-list/cubit/nice-base-list.cubit.dart
@@ -13,10 +13,11 @@ class NiceBaseListCubit<D> extends NiceBaseCubit<NiceBaseListState<D>> {
 
   factory NiceBaseListCubit.of(BuildContext context) => BlocProvider.of(context);
 
-  Future<void> load() async {
+  Future<void> load({bool showLoading = true}) async {
     emit(state.copyWith(error: false));
 
     await wrap(
+      loading: showLoading,
       callback: () async {
         final result = await config.filterApi.filter(
           NiceFilterModel(


### PR DESCRIPTION
Juste un ajout pour ajouter l'option de ne pas montrer le loading spinner par defaut de la nicebaselist quand on load la liste. (Par exemple: dans mon cas il y a un indicateur de loading pour le pull to refresh, cela permet de ne montrer que ce dernier).