### PR TITLE
make english be the default locale

### DIFF
--- a/lib/src/localizations/nice.localizations.dart
+++ b/lib/src/localizations/nice.localizations.dart
@@ -23,7 +23,7 @@ class NiceLocalizations {
     DefaultCupertinoLocalizations.delegate,
   ];
 
-  static List<Locale> get supportedLocales => const [Locale("fr", "CA"), Locale("en", "CA")];
+  static List<Locale> get supportedLocales => const [Locale("en", "CA"), Locale("fr", "CA")];
 
   NiceLocalizations(this.locale) {
     Intl.defaultLocale = locale.toString();


### PR DESCRIPTION
If the browser's language is set to anything other than English in our application - such as Arabic - the login page will appear in French due to the order of locales declared in this file. 

This only occurs on the login page, or other pages that don't require a logged-in user, since in those cases we localize based on the user's preference language stored in our db.

If you or someone else has a use case where they would want French to be the default locale, a long-term change could be to load the list of locales from a configuration file. 