### PR TITLE
Modification du onboarding, ne pas permettre de skip les demandes de permission pour les politiques de Apple

### DIFF
--- a/lib/src/onboarding/permission/onboarding-permission-sequence.configuration.dart
+++ b/lib/src/onboarding/permission/onboarding-permission-sequence.configuration.dart
@@ -7,7 +7,6 @@ class NiceOnboardingPermissionConfiguration {
   final Widget title;
   final Widget paragraph;
   final String activate;
-  final String activateLater;
   final Future<void> Function()? onActivated;
 
   const NiceOnboardingPermissionConfiguration({
@@ -16,7 +15,6 @@ class NiceOnboardingPermissionConfiguration {
     required this.title,
     required this.paragraph,
     required this.activate,
-    required this.activateLater,
     this.onActivated,
   });
 }

--- a/lib/src/onboarding/permission/onboarding-permission.page.dart
+++ b/lib/src/onboarding/permission/onboarding-permission.page.dart
@@ -49,7 +49,7 @@ class _NiceOnboardingPermissionPageState extends State<NiceOnboardingPermissionP
                 ],
               ),
             ),
-            _buildButtons(),
+            _buildButton(),
             const SizedBox(height: 16),
           ],
         ),
@@ -67,33 +67,24 @@ class _NiceOnboardingPermissionPageState extends State<NiceOnboardingPermissionP
     }
   }
 
-  Widget _buildButtons() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        ElevatedButton(
-          onPressed: loading ? null : _activate,
-          child: loading
-              ? const SizedBox(
-                  height: 24,
-                  width: 24,
-                  child: CircularProgressIndicator(),
-                )
-              : Text(
-                  widget.configuration.activate,
-                  style: const TextStyle(
-                    color: Colors.white,
-                  ),
+  Widget _buildButton() {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: loading ? null : _activate,
+        child: loading
+            ? const SizedBox(
+                height: 24,
+                width: 24,
+                child: CircularProgressIndicator(),
+              )
+            : Text(
+                widget.configuration.activate,
+                style: const TextStyle(
+                  color: Colors.white,
                 ),
-        ),
-        const SizedBox(height: 20),
-        TextButton(
-          onPressed: widget.onNext,
-          child: Text(
-            widget.configuration.activateLater,
-          ),
-        ),
-      ],
+              ),
+      ),
     );
   }
 


### PR DESCRIPTION
En gros cela enleve le bouton qui permet de skip les permissions, cela oblige donc l'utilisateur a ouvrir le menu natif, peu importe s'il souhaite ou non donner la permission à l'application (notamment les notifications et la geolocalisation)

en lien avec la pr de premier soins