### PR TITLE
NiceLocalization BuildContext extension

### DIFF
--- a/example/assets/localizations/en.json
+++ b/example/assets/localizations/en.json
@@ -5,5 +5,15 @@
                 "per_page": "Per page"
             }
         }
+    },
+    "home": {
+        "pages": {
+            "onboarding": "Onboarding",
+            "page_view_form": "Page view form",
+            "auth": "Auth",
+            "radio_expandable_cards": "Radio expandable cards",
+            "infinite_scroll_base_list": "Infinite scroll base list",
+            "paginated_base_list": "Paginated base list"
+        }
     }
 }

--- a/example/assets/localizations/fr.json
+++ b/example/assets/localizations/fr.json
@@ -5,5 +5,15 @@
                 "per_page": "Par page"
             }
         }
+    },
+    "home": {
+        "pages": {
+            "onboarding": "Intégration",
+            "page_view_form": "Formulaire de visualisation de page",
+            "auth": "Authentification",
+            "radio_expandable_cards": "Cartes extensibles radio",
+            "infinite_scroll_base_list": "Liste de base à défilement infini",
+            "paginated_base_list": "Liste de base paginée"
+        }
     }
 }

--- a/example/lib/cubit/app.cubit.dart
+++ b/example/lib/cubit/app.cubit.dart
@@ -1,0 +1,11 @@
+import "package:example/cubit/app.state.dart";
+import "package:flutter/widgets.dart";
+import "package:flutter_bloc/flutter_bloc.dart";
+
+class AppCubit extends Cubit<AppState> {
+  AppCubit() : super(const AppState());
+
+  void setOverrideLocale(Locale overrideLocale) {
+    emit(state.copyWith(overrideLocale: overrideLocale));
+  }
+}

--- a/example/lib/cubit/app.state.dart
+++ b/example/lib/cubit/app.state.dart
@@ -1,0 +1,22 @@
+import "dart:ui";
+
+import "package:equatable/equatable.dart";
+
+class AppState extends Equatable {
+  final Locale? overrideLocale;
+
+  const AppState({
+    this.overrideLocale,
+  });
+
+  AppState copyWith({
+    Locale? overrideLocale,
+  }) {
+    return AppState(
+      overrideLocale: overrideLocale ?? this.overrideLocale,
+    );
+  }
+
+  @override
+  List<Object?> get props => [overrideLocale];
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,6 @@
 import "package:device_preview/device_preview.dart";
+import "package:example/cubit/app.cubit.dart";
+import "package:example/cubit/app.state.dart";
 import "package:example/pages/auth/auth.page.dart";
 import "package:example/pages/base-list/infinite-scroll-base-list.page.dart";
 import "package:example/pages/base-list/paginated-base-list.page.dart";
@@ -7,6 +9,7 @@ import "package:example/pages/onboarding.page.dart";
 import "package:example/pages/page-view-form.page.dart";
 import "package:example/pages/radio-expandable-cards.page.dart";
 import "package:flutter/material.dart";
+import "package:flutter_bloc/flutter_bloc.dart";
 import "package:go_router/go_router.dart";
 import "package:nice_flutter_kit/nice_flutter_kit.dart";
 
@@ -37,32 +40,32 @@ class MyApp extends StatefulWidget {
   static const pageRoutes = <RouteData>[
     RouteData(
       path: "/onboarding",
-      title: "Onboarding",
+      titleKey: "home.pages.onboarding",
       child: OnboardingPage(),
     ),
     RouteData(
       path: "/page-view-form",
-      title: "Page view form",
+      titleKey: "home.pages.page_view_form",
       child: PageViewFormPage(),
     ),
     RouteData(
       path: "/auth",
-      title: "Auth",
+      titleKey: "home.pages.auth",
       child: AuthPage(),
     ),
     RouteData(
       path: "/radio-expandable-cards",
-      title: "Radio expandable cards",
+      titleKey: "home.pages.radio_expandable_cards",
       child: RadioExpandableCardsPage(),
     ),
     RouteData(
       path: "/base-list/infinite-scroll",
-      title: "Infinite scroll base list",
+      titleKey: "home.pages.infinite_scroll_base_list",
       child: InfiniteScrollLoadedBaseListPage(),
     ),
     RouteData(
       path: "/base-list/paginated",
-      title: "Paginated base list",
+      titleKey: "home.pages.paginated_base_list",
       child: PaginatedBaseListPage(),
     ),
   ];
@@ -90,31 +93,37 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      routeInformationParser: _router.routeInformationParser,
-      routerDelegate: _router.routerDelegate,
-      title: "Flutter Demo",
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
+    return BlocProvider<AppCubit>(
+      create: (context) => AppCubit(),
+      child: BlocSelector<AppCubit, AppState, Locale?>(
+        selector: (state) => state.overrideLocale,
+        builder: (context, overrideLocale) => MaterialApp.router(
+          routeInformationParser: _router.routeInformationParser,
+          routerDelegate: _router.routerDelegate,
+          title: "Flutter Demo",
+          debugShowCheckedModeBanner: false,
+          theme: ThemeData(
+            primarySwatch: Colors.blue,
+          ),
+          locale: overrideLocale ?? DevicePreview.locale(context),
+          builder: DevicePreview.appBuilder,
+          supportedLocales: NiceLocalizations.supportedLocales,
+          localizationsDelegates: NiceLocalizations.delegates,
+          localeResolutionCallback: NiceLocalizations.localResolutionCallback,
+        ),
       ),
-      locale: DevicePreview.locale(context),
-      builder: DevicePreview.appBuilder,
-      supportedLocales: NiceLocalizations.supportedLocales,
-      localizationsDelegates: NiceLocalizations.delegates,
-      localeResolutionCallback: NiceLocalizations.localResolutionCallback,
     );
   }
 }
 
 class RouteData {
   final String path;
-  final String title;
+  final String titleKey;
   final Widget child;
 
   const RouteData({
     required this.path,
-    required this.title,
+    required this.titleKey,
     required this.child,
   });
 }

--- a/example/lib/pages/home.page.dart
+++ b/example/lib/pages/home.page.dart
@@ -1,6 +1,9 @@
+import "package:example/cubit/app.cubit.dart";
 import "package:example/main.dart";
 import "package:flutter/material.dart";
+import "package:flutter_bloc/flutter_bloc.dart";
 import "package:go_router/go_router.dart";
+import "package:nice_flutter_kit/nice_flutter_kit.dart";
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
@@ -18,11 +21,35 @@ class HomePage extends StatelessWidget {
                 child: ElevatedButton(
                   style: ElevatedButton.styleFrom(padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 16)),
                   onPressed: () => context.push(route.path),
-                  child: Text(route.title),
+                  child: Text(
+                    context.translate(route.titleKey),
+                  ),
                 ),
               ),
+            const SizedBox(height: 32),
+            _buildLocaleSelector(),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildLocaleSelector() {
+    return Builder(
+      builder: (context) => DropdownButtonFormField(
+        value: NiceLocalizations.of(context).locale,
+        items: [
+          for (final locale in NiceLocalizations.supportedLocales)
+            DropdownMenuItem(
+              value: locale,
+              child: Text(locale.languageCode),
+            ),
+        ],
+        onChanged: (locale) {
+          if (locale != null) {
+            context.read<AppCubit>().setOverrideLocale(locale);
+          }
+        },
       ),
     );
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -106,7 +106,7 @@ packages:
     source: hosted
     version: "2.1.2"
   equatable:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: equatable
       sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
 
   device_preview: 1.1.0
+  equatable: 2.0.5
   expandable: 5.0.1
   faker: 2.1.0
   flutter_bloc: 8.1.2

--- a/lib/src/configs/config.dart
+++ b/lib/src/configs/config.dart
@@ -29,7 +29,5 @@ class NiceConfig {
       // Hardcoded permissionsTypes for now
       await NiceConfig.onboardingConfig!.init();
     }
-
-    NiceLocalizations.initializeTimeago();
   }
 }

--- a/lib/src/localizations/nice-localizations.extension.dart
+++ b/lib/src/localizations/nice-localizations.extension.dart
@@ -1,0 +1,16 @@
+import "package:flutter/widgets.dart";
+import "package:nice_flutter_kit/nice_flutter_kit.dart";
+
+extension NiceLocalizationBuildContextExtension on BuildContext {
+  String translate(
+    String key, {
+    Map<String, String>? variables,
+    String? overrideLocale,
+  }) {
+    return NiceLocalizations.of(this).translate(
+      key,
+      variables: variables,
+      overrideLocale: overrideLocale,
+    );
+  }
+}

--- a/lib/src/localizations/nice.localizations.dart
+++ b/lib/src/localizations/nice.localizations.dart
@@ -9,7 +9,7 @@ import "package:nice_flutter_kit/nice_flutter_kit.dart";
 import "package:timeago/timeago.dart" as timeago;
 
 class NiceLocalizations {
-  Locale locale;
+  final Locale locale;
   final Map<String, Map<String, dynamic>> _translations = {};
 
   factory NiceLocalizations.of(BuildContext context) {
@@ -33,11 +33,6 @@ class NiceLocalizations {
     timeago.setLocaleMessages("en", timeago.EnMessages());
   }
 
-  static void initializeTimeago() {
-    timeago.setLocaleMessages("fr", timeago.FrShortMessages());
-    timeago.setLocaleMessages("en", timeago.EnMessages());
-  }
-
   static Locale localResolutionCallback(Locale? locale, Iterable<Locale> supportedLocales) {
     if (locale == null) {
       return supportedLocales.first;
@@ -52,10 +47,9 @@ class NiceLocalizations {
     return supportedLocales.first;
   }
 
-  Future load() async {
+  Future<void> load() async {
     for (final supportedLocale in supportedLocales) {
-      final String jsonString =
-          await rootBundle.loadString("assets/localizations/${supportedLocale.languageCode}.json");
+      final jsonString = await rootBundle.loadString("assets/localizations/${supportedLocale.languageCode}.json");
       final Map<String, dynamic> jsonMap = json.decode(jsonString);
       _translations.putIfAbsent(supportedLocale.languageCode, () {
         return jsonMap.map((key, value) {
@@ -111,7 +105,8 @@ class _NiceLocalizationsDelegate extends LocalizationsDelegate<NiceLocalizations
 
   @override
   bool isSupported(Locale locale) {
-    return NiceLocalizations.supportedLocales.map((locale) => locale.languageCode).contains(locale.languageCode);
+    return NiceLocalizations.supportedLocales
+        .any((supportedLocale) => supportedLocale.languageCode == locale.languageCode);
   }
 
   @override

--- a/lib/src/localizations/public.dart
+++ b/lib/src/localizations/public.dart
@@ -1,1 +1,2 @@
+export "nice-localizations.extension.dart";
 export "nice.localizations.dart";


### PR DESCRIPTION
Instead of `NiceLocalizations.of(context).translate("my.key")`, we can now do `context.translate("my.key")`.