### PR TITLE
feat(base-list): add standalone widget for empty state

### DIFF
--- a/example/lib/pages/base-list/infinite-scroll-base-list.page.dart
+++ b/example/lib/pages/base-list/infinite-scroll-base-list.page.dart
@@ -46,15 +46,19 @@ class InfiniteScrollLoadedBaseListPage extends StatelessWidget {
               ),
             ),
             Expanded(
-              child: NiceBaseListBody<Accounts>.separated(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
-                builder: (_, account) => AccountTile(account: account),
-                separatorBuilder: (_) => const SizedBox(height: 16),
-                pageLoadingIndicator: const Padding(
-                  padding: EdgeInsets.only(top: 20),
-                  child: LinearProgressIndicator(),
+              child: NiceBaseListEmptyState<Accounts>(
+                emptyStateBuilder: (context) => const Center(
+                  child: Text("Empty state"),
                 ),
-                emptyStateBuilder: (context) => const Text("Empty state"),
+                child: NiceBaseListBody<Accounts>.separated(
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+                  builder: (_, account) => AccountTile(account: account),
+                  separatorBuilder: (_) => const SizedBox(height: 16),
+                  pageLoadingIndicator: const Padding(
+                    padding: EdgeInsets.only(top: 20),
+                    child: LinearProgressIndicator(),
+                  ),
+                ),
               ),
             ),
           ],

--- a/example/lib/pages/base-list/paginated-base-list.page.dart
+++ b/example/lib/pages/base-list/paginated-base-list.page.dart
@@ -48,11 +48,15 @@ class PaginatedBaseListPage extends StatelessWidget {
               ),
             ),
             Expanded(
-              child: NiceBaseListBody<Accounts>.separated(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
-                builder: (_, account) => AccountTile(account: account),
-                separatorBuilder: (_) => const SizedBox(height: 16),
-                emptyStateBuilder: (context) => const Text("Empty state"),
+              child: NiceBaseListEmptyState<Accounts>(
+                emptyStateBuilder: (context) => const Center(
+                  child: Text("Empty state"),
+                ),
+                child: NiceBaseListBody<Accounts>.separated(
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+                  builder: (_, account) => AccountTile(account: account),
+                  separatorBuilder: (_) => const SizedBox(height: 16),
+                ),
               ),
             ),
             NiceBaseListPaginator<Accounts>(

--- a/lib/src/base-list/widgets/base-list-empty-state.widget.dart
+++ b/lib/src/base-list/widgets/base-list-empty-state.widget.dart
@@ -1,0 +1,28 @@
+import "package:flutter/widgets.dart";
+import "package:nice_flutter_kit/nice_flutter_kit.dart";
+
+class NiceBaseListEmptyState<D> extends StatelessWidget {
+  final WidgetBuilder emptyStateBuilder;
+  final Widget? child;
+
+  const NiceBaseListEmptyState({
+    super.key,
+    required this.emptyStateBuilder,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return NiceBaseListCubitBuilder<D>(
+      buildWhen: (prev, curr) =>
+          prev.values.isEmpty != curr.values.isEmpty || prev.initialLoadCompleted != curr.initialLoadCompleted,
+      builder: (context, state) {
+        if (state.values.isNotEmpty || !state.initialLoadCompleted) {
+          return child ?? const SizedBox.shrink();
+        }
+
+        return emptyStateBuilder(context);
+      },
+    );
+  }
+}

--- a/lib/src/base-list/widgets/base-list-empty-state.widget.dart
+++ b/lib/src/base-list/widgets/base-list-empty-state.widget.dart
@@ -1,6 +1,15 @@
 import "package:flutter/widgets.dart";
 import "package:nice_flutter_kit/nice_flutter_kit.dart";
 
+/// This widget is part of the base list, and MUST be a child of [NiceBaseListConfig].
+///
+/// The [D] generic type refers to the filtered type (e.g. `Accounts`). It must be provided and it must be the same type
+/// as the [NiceBaseListConfig].
+///
+/// This widget is used to show an empty state whenever the list has no items.
+/// The empty state will only be showed if both of the following conditions are true:
+/// - The list has no values
+/// - The list has initialized and the first load has been completed
 class NiceBaseListEmptyState<D> extends StatelessWidget {
   final WidgetBuilder emptyStateBuilder;
   final Widget? child;

--- a/lib/src/base-list/widgets/body/base-list-body.widget.dart
+++ b/lib/src/base-list/widgets/body/base-list-body.widget.dart
@@ -69,6 +69,7 @@ class NiceBaseListBody<D> extends StatelessWidget {
   final double loadingThreshold;
 
   /// [WidgetBuilder] that will display the resulting [Widget] when there are no items in the list.
+  @Deprecated("replaced by NiceBaseListEmptyState")
   final WidgetBuilder? emptyStateBuilder;
 
   NiceBaseListBody({
@@ -91,7 +92,7 @@ class NiceBaseListBody<D> extends StatelessWidget {
     this.loadingThreshold = 400,
     this.pageLoadingIndicator,
     this.pageLoadingIndicatorMaintainSize = true,
-    this.emptyStateBuilder,
+    @Deprecated("replaced by NiceBaseListEmptyState") this.emptyStateBuilder,
   }) : delegate = NiceBaseListBodyBuilderDelegate(builder);
 
   NiceBaseListBody.indexed({
@@ -114,7 +115,7 @@ class NiceBaseListBody<D> extends StatelessWidget {
     this.loadingThreshold = 400,
     this.pageLoadingIndicator,
     this.pageLoadingIndicatorMaintainSize = true,
-    this.emptyStateBuilder,
+    @Deprecated("replaced by NiceBaseListEmptyState") this.emptyStateBuilder,
   }) : delegate = NiceBaseListBodyChildIndexedBuilderDelegate(builder);
 
   NiceBaseListBody.separated({
@@ -138,7 +139,7 @@ class NiceBaseListBody<D> extends StatelessWidget {
     this.loadingThreshold = 400,
     this.pageLoadingIndicator,
     this.pageLoadingIndicatorMaintainSize = true,
-    this.emptyStateBuilder,
+    @Deprecated("replaced by NiceBaseListEmptyState") this.emptyStateBuilder,
   }) : delegate = NiceBaseListBodyChildSeparatedBuilderDelegate(
           builder: builder,
           separatorBuilder: separatorBuilder,
@@ -165,7 +166,7 @@ class NiceBaseListBody<D> extends StatelessWidget {
     this.loadingThreshold = 400,
     this.pageLoadingIndicator,
     this.pageLoadingIndicatorMaintainSize = true,
-    this.emptyStateBuilder,
+    @Deprecated("replaced by NiceBaseListEmptyState") this.emptyStateBuilder,
   }) : delegate = NiceBaseListBodyChildSeparatedIndexedBuilderDelegate(
           builder: builder,
           separatorBuilder: separatorBuilder,
@@ -191,7 +192,7 @@ class NiceBaseListBody<D> extends StatelessWidget {
     this.loadingThreshold = 400,
     this.pageLoadingIndicator,
     this.pageLoadingIndicatorMaintainSize = true,
-    this.emptyStateBuilder,
+    @Deprecated("replaced by NiceBaseListEmptyState") this.emptyStateBuilder,
   });
 
   @override

--- a/lib/src/base-list/widgets/public.dart
+++ b/lib/src/base-list/widgets/public.dart
@@ -1,4 +1,5 @@
 export "./base-list-config.widget.dart";
+export "./base-list-empty-state.widget.dart";
 export "./base-list-error-listener.widget.dart";
 export "./base-list-loading-indicator.widget.dart";
 export "./base-list-paginator.widget.dart";


### PR DESCRIPTION
Add a standalone widget for showing an empty state, and deprecate the `emptyStateBuilder` field in the `NiceBaseListBody`, in order to make the base list more modular.